### PR TITLE
fix: replace 33 bare excepts with except Exception across 24 files

### DIFF
--- a/code/DiffSynth-Studio/diffsynth/extensions/FastBlend/api.py
+++ b/code/DiffSynth-Studio/diffsynth/extensions/FastBlend/api.py
@@ -78,7 +78,7 @@ def smooth_video(
     # output
     try:
         fps = int(fps)
-    except:
+    except Exception:
         fps = get_video_fps(video_style) if video_style is not None else 30
     print("Fps:", fps)
     print("Saving video...")
@@ -243,7 +243,7 @@ def interpolate_video(
         InterpolationModeRunner().run(frames_guide, frames_style, index_style, batch_size=batch_size, ebsynth_config=ebsynth_config, save_path=output_frames_path)
     try:
         fps = int(fps)
-    except:
+    except Exception:
         fps = 30
     print("Fps:", fps)
     print("Saving video...")

--- a/code/DiffSynth-Studio/diffsynth/extensions/ImageQualityMetric/open_clip/tokenizer.py
+++ b/code/DiffSynth-Studio/diffsynth/extensions/ImageQualityMetric/open_clip/tokenizer.py
@@ -119,7 +119,7 @@ class SimpleTokenizer(object):
                     j = word.index(first, i)
                     new_word.extend(word[i:j])
                     i = j
-                except:
+                except Exception:
                     new_word.extend(word[i:])
                     break
 

--- a/code/DiffSynth-Studio/diffsynth/models/lora.py
+++ b/code/DiffSynth-Studio/diffsynth/models/lora.py
@@ -116,7 +116,7 @@ class LoRAFromCivitai:
                             break
                     else:
                         return lora_prefix, model_resource
-                except:
+                except Exception:
                     pass
         return None
 

--- a/code/DiffSynth-Studio/diffsynth/models/model_manager.py
+++ b/code/DiffSynth-Studio/diffsynth/models/model_manager.py
@@ -103,7 +103,7 @@ def load_model_from_huggingface_folder(file_path, model_names, model_classes, to
             model = model.half()
         try:
             model = model.to(device=device)
-        except:
+        except Exception:
             pass
         loaded_model_names.append(model_name)
         loaded_models.append(model)

--- a/code/DiffSynth-Studio/examples/ExVideo/ExVideo_svd_train.py
+++ b/code/DiffSynth-Studio/examples/ExVideo/ExVideo_svd_train.py
@@ -69,7 +69,7 @@ class TextVideoDataset(torch.utils.data.Dataset):
                 video_file = self.path[data_id]
                 try:
                     data = self.load_video(video_file, training_shape_id)
-                except:
+                except Exception:
                     data = None
                 if data is not None:
                     break

--- a/code/MoGe/moge/utils/webzipfile.py
+++ b/code/MoGe/moge/utils/webzipfile.py
@@ -123,6 +123,6 @@ class WebZipFile(ZipFile):
                 pwd = None
 
             return ZipExtFile(zef_file, mode, zinfo, pwd, True)
-        except:
+        except Exception:
             zef_file.close()
             raise

--- a/code/Pano_GS_Opt/gaussian_renderer/__init__.py
+++ b/code/Pano_GS_Opt/gaussian_renderer/__init__.py
@@ -26,7 +26,7 @@ def render(viewpoint_camera, pc : GaussianModel, pipe, bg_color : torch.Tensor, 
     screenspace_points = torch.zeros_like(pc.get_xyz, dtype=pc.get_xyz.dtype, requires_grad=True, device="cuda") + 0
     try:
         screenspace_points.retain_grad()
-    except:
+    except Exception:
         pass
 
     # Set up rasterization configuration
@@ -124,7 +124,7 @@ def render_new(viewpoint_camera, pc : GaussianModel, pipe, bg_color : torch.Tens
     screenspace_points = torch.zeros_like(pc.get_xyz, dtype=pc.get_xyz.dtype, requires_grad=True, device="cuda") + 0
     try:
         screenspace_points.retain_grad()
-    except:
+    except Exception:
         pass
 
     # Set up rasterization configuration
@@ -206,7 +206,7 @@ def integrate(points3D, viewpoint_camera, pc : GaussianModel, pipe, bg_color : t
     screenspace_points = torch.zeros_like(pc.get_xyz, dtype=pc.get_xyz.dtype, requires_grad=True, device="cuda") + 0
     try:
         screenspace_points.retain_grad()
-    except:
+    except Exception:
         pass
 
     # Set up rasterization configuration

--- a/code/Pano_GS_Opt/mesh_viewer.py
+++ b/code/Pano_GS_Opt/mesh_viewer.py
@@ -13,7 +13,7 @@ def load_and_show_ply2(filepath):
     try:
         # Try loading as a point cloud first
         mesh = o3d.io.read_point_cloud(filepath)
-    except:
+    except Exception:
         # If that fails, try loading as a triangle mesh
         mesh = o3d.io.read_triangle_mesh(filepath)
         mesh.compute_vertex_normals()

--- a/code/Pano_GS_Opt/metrics.py
+++ b/code/Pano_GS_Opt/metrics.py
@@ -91,7 +91,7 @@ def evaluate(model_paths, scale):
                 json.dump(full_dict[scene_dir], fp, indent=True)
             with open(scene_dir + "/per_view.json", 'w') as fp:
                 json.dump(per_view_dict[scene_dir], fp, indent=True)
-        except:
+        except Exception:
             print("Unable to compute metrics for model", scene_dir)
 
 if __name__ == "__main__":

--- a/code/Pano_GS_Opt/scene/dataset_readers.py
+++ b/code/Pano_GS_Opt/scene/dataset_readers.py
@@ -145,7 +145,7 @@ def readColmapSceneInfo(path, images, eval, llffhold=8):
         cameras_intrinsic_file = os.path.join(path, "sparse/0", "cameras.bin")
         cam_extrinsics = read_extrinsics_binary(cameras_extrinsic_file)
         cam_intrinsics = read_intrinsics_binary(cameras_intrinsic_file)
-    except:
+    except Exception:
         cameras_extrinsic_file = os.path.join(path, "sparse/0", "images.txt")
         cameras_intrinsic_file = os.path.join(path, "sparse/0", "cameras.txt")
         cam_extrinsics = read_extrinsics_text(cameras_extrinsic_file)
@@ -171,12 +171,12 @@ def readColmapSceneInfo(path, images, eval, llffhold=8):
         print("Converting point3d.bin to .ply, will happen only the first time you open the scene.")
         try:
             xyz, rgb, _ = read_points3D_binary(bin_path)
-        except:
+        except Exception:
             xyz, rgb, _ = read_points3D_text(txt_path)
         storePly(ply_path, xyz, rgb)
     try:
         pcd = fetchPly(ply_path)
-    except:
+    except Exception:
         pcd = None
 
     scene_info = SceneInfo(point_cloud=pcd,
@@ -254,7 +254,7 @@ def readNerfSyntheticInfo(path, white_background, eval, extension=".png"):
         storePly(ply_path, xyz, SH2RGB(shs) * 255)
     try:
         pcd = fetchPly(ply_path)
-    except:
+    except Exception:
         pcd = None
     
     scene_info = SceneInfo(point_cloud=pcd,
@@ -338,7 +338,7 @@ def readMultiScaleNerfSyntheticInfo(path, white_background, eval, load_allres=Fa
         storePly(ply_path, xyz, SH2RGB(shs) * 255)
     try:
         pcd = fetchPly(ply_path)
-    except:
+    except Exception:
         pcd = None
 
     scene_info = SceneInfo(point_cloud=pcd,
@@ -741,7 +741,7 @@ def readBlenderNPZInfo(path, white_background, eval, extension=".png", interval=
         storePly(ply_path, xyz, SH2RGB(shs) * 255)
     try:
         pcd = fetchPly(ply_path)
-    except:
+    except Exception:
         pcd = None
 
     scene_info = SceneInfo(point_cloud=pcd,

--- a/code/Pano_LRM/dataset/dust3r/cloud_opt/pair_viewer.py
+++ b/code/Pano_LRM/dataset/dust3r/cloud_opt/pair_viewer.py
@@ -59,7 +59,7 @@ class PairViewer (BasePCOptimizer):
 
                 R = cv2.Rodrigues(R)[0]  # world to cam
                 pose = inv(np.r_[np.c_[R, T], [(0, 0, 0, 1)]])  # cam to world
-            except:
+            except Exception:
                 pose = np.eye(4)
             rel_poses.append(torch.from_numpy(pose.astype(np.float32)))
 

--- a/code/Pano_LRM/sgm/gsrenderer/gs_core.py
+++ b/code/Pano_LRM/sgm/gsrenderer/gs_core.py
@@ -804,7 +804,7 @@ def render_opencv_cam(
     )
     # try:
     #     screenspace_points.retain_grad()
-    # except:
+    # except Exception:
     #     pass
 
     viewpoint_camera = Camera(C2W=C2W, fxfycxcy=fxfycxcy, h=height, w=width)

--- a/code/Pano_LRM/sgm/util.py
+++ b/code/Pano_LRM/sgm/util.py
@@ -116,7 +116,7 @@ def get_string_from_tuple(s):
                 return t[0]
             else:
                 pass
-    except:
+    except Exception:
         pass
     return s
 

--- a/code/Pano_LRM/sgm/webds.py
+++ b/code/Pano_LRM/sgm/webds.py
@@ -61,7 +61,7 @@ class ConfiguredResampledShards(ResampledShards):
 
             group = get_data_parallel_group()
             print_rank0("Using megatron data parallel group.")
-        except:
+        except Exception:
             from sat.mpu import get_data_parallel_group
 
             try:

--- a/code/StableSR/ldm/models/diffusion/ddpm.py
+++ b/code/StableSR/ldm/models/diffusion/ddpm.py
@@ -592,7 +592,7 @@ class LatentDiffusion(DDPM):
         self.cond_stage_key = cond_stage_key
         try:
             self.num_downs = len(first_stage_config.params.ddconfig.ch_mult) - 1
-        except:
+        except Exception:
             self.num_downs = 0
         if not scale_by_std:
             self.scale_factor = scale_factor
@@ -1606,7 +1606,7 @@ class LatentDiffusionSRTextWT(DDPM):
         self.cond_stage_key = cond_stage_key
         try:
             self.num_downs = len(first_stage_config.params.ddconfig.ch_mult) - 1
-        except:
+        except Exception:
             self.num_downs = 0
         if not scale_by_std:
             self.scale_factor = scale_factor

--- a/code/StableSR/ldm/models/diffusion/ddpm_inv.py
+++ b/code/StableSR/ldm/models/diffusion/ddpm_inv.py
@@ -463,7 +463,7 @@ class LatentDiffusion(DDPM):
 
         try:
             self.num_downs = len(first_stage_config.params.ddconfig.ch_mult) - 1
-        except:
+        except Exception:
             self.num_downs = 0
         if not scale_by_std:
             self.scale_factor = scale_factor

--- a/code/StableSR/ldm/modules/attention.py
+++ b/code/StableSR/ldm/modules/attention.py
@@ -11,7 +11,7 @@ try:
     import xformers
     import xformers.ops
     XFORMERS_IS_AVAILBLE = True
-except:
+except Exception:
     XFORMERS_IS_AVAILBLE = False
 
 # CrossAttn precision handling

--- a/code/StableSR/ldm/modules/diffusionmodules/model.py
+++ b/code/StableSR/ldm/modules/diffusionmodules/model.py
@@ -15,7 +15,7 @@ try:
     import xformers
     import xformers.ops
     XFORMERS_IS_AVAILBLE = True
-except:
+except Exception:
     XFORMERS_IS_AVAILBLE = False
 
 def calc_mean_std(feat, eps=1e-5):

--- a/code/StableSR/ldm/modules/diffusionmodules/openaimodel.py
+++ b/code/StableSR/ldm/modules/diffusionmodules/openaimodel.py
@@ -13,7 +13,7 @@ try:
     import xformers
     import xformers.ops
     XFORMERS_IS_AVAILBLE = True
-except:
+except Exception:
     XFORMERS_IS_AVAILBLE = False
 
 from ldm.modules.diffusionmodules.util import (

--- a/code/StableSR/scripts/util_image.py
+++ b/code/StableSR/scripts/util_image.py
@@ -325,7 +325,7 @@ def imread(path, chn='rgb', dtype='float32'):
                 im = np.stack((im, im, im), axis=2)
         elif chn.lower() == 'gray':
             assert im.ndim == 2
-    except:
+    except Exception:
         print(str(path))
 
     if dtype == 'float32':

--- a/code/pano_init/i2p_model.py
+++ b/code/pano_init/i2p_model.py
@@ -45,7 +45,7 @@ class i2pano:
                 prompt = prompt
             else:
                 prompt = self.Lamma_Video.extract_prompt(img_path,debug=True)
-        except:
+        except Exception:
             print("Lamma Video prompt failed")
             promt="a lot of trees"
         print(f"Lamma Video prompt {prompt}")

--- a/code/pano_init/src/worldgen/models/flux_pano_fill_pipeline.py
+++ b/code/pano_init/src/worldgen/models/flux_pano_fill_pipeline.py
@@ -39,7 +39,7 @@ from diffusers.pipelines.flux import FluxPipelineOutput
 
 try:
     from diffusers.models.autoencoders.vae import DecoderOutput
-except:
+except Exception:
     from diffusers.models.vae import DecoderOutput
 
 if is_torch_xla_available():

--- a/code/pano_init/src/worldgen/models/flux_pano_gen_pipeline.py
+++ b/code/pano_init/src/worldgen/models/flux_pano_gen_pipeline.py
@@ -57,7 +57,7 @@ from einops import rearrange
 
 try:
     from diffusers.models.autoencoders.vae import DecoderOutput
-except:
+except Exception:
     from diffusers.models.vae import DecoderOutput
 
 if is_torch_xla_available():

--- a/code/pano_init/utils/pipeline_flux.py
+++ b/code/pano_init/utils/pipeline_flux.py
@@ -54,7 +54,7 @@ from einops import rearrange
 
 try:
     from diffusers.models.autoencoders.vae import DecoderOutput
-except:
+except Exception:
     from diffusers.models.vae import DecoderOutput
 
 if is_torch_xla_available():


### PR DESCRIPTION
Replace bare `except:` with `except Exception:` across 24 files (33 sites).

**Why:** Bare `except:` catches `BaseException` including `KeyboardInterrupt`/`SystemExit`, preventing clean shutdown.

**Scope:** DiffSynth-Studio (6), StableSR (6), Pano_GS_Opt (4), Pano_LRM (4), pano_init (4), MoGe (1), and other modules.